### PR TITLE
Fix git parsing race condition

### DIFF
--- a/aqui_brain_dump/note.py
+++ b/aqui_brain_dump/note.py
@@ -54,9 +54,8 @@ class Note:
         note = cls.notes.get(path_to_url(rel_path), False)
         if note:
             return note
-        note = cls(file_path)
+        note = cls(file_path, parse_git=parse_git)
         note.parse_file()
-        note.parse_git = parse_git
         return note
 
     @classmethod


### PR DESCRIPTION
## Summary
- ensure parse_git flag is set before scheduling git metadata tasks

## Testing
- `python -m pip install -q -r requirements.txt`
- manual sanity check using minimal templates

------
https://chatgpt.com/codex/tasks/task_e_686ce3da03c48325b32c8dfd651edddb