### PR TITLE
Highlight missing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each note that ends with ``.md`` will be transformed into a folder such as as ``
 
 Each note can have internal links, in which I use the wikilink syntax: ``[[ ]]``. Each link is then appended to the target page, so that lists of backlinks can be built. I find the idea of backlinks crucial for lowering the barrier, since new content can be automatically be shown on older content. 
 
-Also, links to non-existing pages will force the creation of an 'empty' node that only displays backlinks. 
+Also, links to non-existing pages will force the creation of an 'empty' node that only displays backlinks. These links will now receive an additional CSS class ``wikilink-missing`` so they can be styled differently (for example using a lighter yellow).
 
 ## Extra Markdown
 There are some custom solutions embedded into the program. For example, wikilinks parse the presence of ``|`` as a separator for the href. In this way, ``[[target|link]]`` will show up as ``link`` but will be targeted at ``target``. The wikilinks also remove all the spaces and transform them to underscores to be consistent with how I deal with URL's. 

--- a/aqui_brain_dump/backlinks_wikilinks.py
+++ b/aqui_brain_dump/backlinks_wikilinks.py
@@ -8,7 +8,9 @@ possible to build the graph of backlinks, but it still requires a two-pass appro
 ready for the template rendering.
 
 """
+
 import logging
+from pathlib import Path
 
 from markdown.extensions import Extension
 from markdown.inlinepatterns import InlineProcessor
@@ -16,24 +18,24 @@ import xml.etree.ElementTree as etree
 import re
 
 
-
 logger = logging.getLogger(__name__)
 
+
 def build_url(label, base, end):
-    """ Build a url from the label, a base, and an end. """
-    label = label.split('|')[0]
-    clean_label = re.sub(r'([ ]+_)|(_[ ]+)|([ ]+)', '_', label)
-    return '{}{}{}'.format(base, clean_label, end)
+    """Build a url from the label, a base, and an end."""
+    label = label.split("|")[0]
+    clean_label = re.sub(r"([ ]+_)|(_[ ]+)|([ ]+)", "_", label)
+    return "{}{}{}".format(base, clean_label, end)
 
 
 class WikiLinkExtension(Extension):
 
     def __init__(self, **kwargs):
         self.config = {
-            'base_url': ['/', 'String to append to beginning or URL.'],
-            'end_url': ['/', 'String to append to end of URL.'],
-            'html_class': ['wikilink', 'CSS hook. Leave blank for none.'],
-            'build_url': [build_url, 'Callable formats URL from label.'],
+            "base_url": ["/", "String to append to beginning or URL."],
+            "end_url": ["/", "String to append to end of URL."],
+            "html_class": ["wikilink", "CSS hook. Leave blank for none."],
+            "build_url": [build_url, "Callable formats URL from label."],
         }
 
         super().__init__(**kwargs)
@@ -45,10 +47,10 @@ class WikiLinkExtension(Extension):
         self.md = md
         self.reset()
         # append to end of inline patterns
-        WIKILINK_RE = r'\[\[([\w_\|\/ -.]+)\]\]'
+        WIKILINK_RE = r"\[\[([\w_\|\/ -.]+)\]\]"
         wikilinkPattern = WikiLinksInlineProcessor(WIKILINK_RE, self.getConfigs())
         wikilinkPattern.md = md
-        md.inlinePatterns.register(wikilinkPattern, 'wikilink', 75)
+        md.inlinePatterns.register(wikilinkPattern, "wikilink", 75)
 
 
 class WikiLinksInlineProcessor(InlineProcessor):
@@ -60,38 +62,52 @@ class WikiLinksInlineProcessor(InlineProcessor):
         if m.group(1).strip():
             base_url, end_url, html_class = self._getMeta()
             label = m.group(1).strip()
-            text = label.split('|')[-1]
-            href = label.split('|')[0].lower().replace(' ', '_')
-            if href.startswith('/'):
+            text = label.split("|")[-1]
+            href = label.split("|")[0].lower().replace(" ", "_")
+            if href.startswith("/"):
                 href = href[1:]
-            url = self.config['build_url'](href, base_url, end_url)
-            logger.debug(f'Got link to {url}')
-            if not hasattr(self.md, 'links'):
+            url = self.config["build_url"](href, base_url, end_url)
+            logger.debug(f"Got link to {url}")
+            if not hasattr(self.md, "links"):
                 self.md.links = set()
 
             self.md.links.add(url)
-            a = etree.Element('a')
+            a = etree.Element("a")
             a.text = text
-            a.set('href', url.lower())
+            a.set("href", url.lower())
 
+            classes = []
             if html_class:
-                a.set('class', html_class)
+                classes.append(html_class)
+
+            try:
+                from aqui_brain_dump import content_path
+            except Exception:
+                c_path = Path("./content")
+            else:
+                c_path = content_path
+
+            if not (c_path / f"{href}.md").is_file():
+                classes.append("wikilink-missing")
+
+            if classes:
+                a.set("class", " ".join(classes))
         else:
-            a = ''
+            a = ""
         return a, m.start(0), m.end(0)
 
     def _getMeta(self):
-        """ Return meta data or config data. """
-        base_url = self.config['base_url']
-        end_url = self.config['end_url']
-        html_class = self.config['html_class']
-        if hasattr(self.md, 'Meta'):
-            if 'wiki_base_url' in self.md.Meta:
-                base_url = self.md.Meta['wiki_base_url'][0]
-            if 'wiki_end_url' in self.md.Meta:
-                end_url = self.md.Meta['wiki_end_url'][0]
-            if 'wiki_html_class' in self.md.Meta:
-                html_class = self.md.Meta['wiki_html_class'][0]
+        """Return meta data or config data."""
+        base_url = self.config["base_url"]
+        end_url = self.config["end_url"]
+        html_class = self.config["html_class"]
+        if hasattr(self.md, "Meta"):
+            if "wiki_base_url" in self.md.Meta:
+                base_url = self.md.Meta["wiki_base_url"][0]
+            if "wiki_end_url" in self.md.Meta:
+                end_url = self.md.Meta["wiki_end_url"][0]
+            if "wiki_html_class" in self.md.Meta:
+                html_class = self.md.Meta["wiki_html_class"][0]
         return base_url, end_url, html_class
 
 


### PR DESCRIPTION
## Summary
- mark wikilinks pointing to missing notes with `wikilink-missing` class
- mention how missing links can be styled in README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ceacab8bc8325b37182b227dcc855